### PR TITLE
Fixed default home to work with user generators

### DIFF
--- a/sway/config
+++ b/sway/config
@@ -30,7 +30,7 @@ set $shutdown sudo -A shutdown -h now
 set $reboot sudo -A reboot
 set $netrefresh --no-startup-id sudo -A systemctl restart NetworkManager
 set $hibernate sudo -A systemctl suspend
-set $HOME /home/alpha
+set $HOME /home/zeus
 
 # #---Dropdown Windows---# #
 # General dropdown window traits. The order can matter.


### PR DESCRIPTION
Change default home directory to /home/zeus since that string is search for in dialogarchsinstaller and more